### PR TITLE
Support share amounts less than 1.0

### DIFF
--- a/mssb_1099b_to_txf.py
+++ b/mssb_1099b_to_txf.py
@@ -43,7 +43,7 @@ section_expr = re.compile(
 row_expr = re.compile(
         r'^(?P<descr>(\w| )+)\s+'
         r'(?P<cusip>\w+)\s+'
-        r'(?P<quantity>\d+\.\d+)\s+'
+        r'(?P<quantity>\d*\.\d+)\s+'
         r'(?P<acquired>(\d+/\d+/\d+|\w+))\s+'
         r'(?P<sold>\d+/\d+/\d+)\s+'
         r'(?P<proceeds>\$[0-9,.]+)\s+'


### PR DESCRIPTION
They are reported without a leading zero in the PDF.