### PR TITLE
fix: correctly classify long term gains

### DIFF
--- a/mssb_1099b_to_txf.py
+++ b/mssb_1099b_to_txf.py
@@ -24,7 +24,7 @@ categories = {
 # only on "^Total".
 categories_pattern = '|'.join(categories)
 section_expr = re.compile(
-        r'('+categories_pattern+r')'
+        r'^('+categories_pattern+r')'
         r'(.*?)'
         r'^Total', re.DOTALL|re.MULTILINE)
 


### PR DESCRIPTION
I noticed that long term gains in the 1099 were being classified as short term gains by mssb_1099b_to_txf.py. The issue is because the short term gains section in the PDF document is terminated with the phrase `Total Short Term – Noncovered Securities`. The python parser was terminating the section based on the word "Total". This left the remainder of the line (" Short Term ...") eligible when searching for the next section. The regex for the start of a section was too lax, so it accepted " Short Term ..." as the start of the next section, leading the code to classify this next section as short term gains even though it actually contained long term trades.

We can fix this by being stricter about the start of each section. Using `^` (with the `re.MULTILINE` flag) enforces that a section only starts if "Short Term"/"Long Term" is located at the very beginning of a line.