### PR TITLE
refactor: use argparse to parse arguments

### DIFF
--- a/mssb_1099b_to_txf.py
+++ b/mssb_1099b_to_txf.py
@@ -2,10 +2,11 @@
 
 """mssb_1099b_to_txf converts simple Morgan Stanley (MSSB) 1099-B PDFs to TXF files."""
 
+import argparse
 import datetime
+import os
 import re
 import subprocess
-import sys
 
 # Codes and structure are defined at
 # https://www.taxdataexchange.org/txf/txf-spec.html
@@ -64,9 +65,13 @@ def parse_sections(text):
     return section_expr.finditer(text)
 
 def main():
-    if len(sys.argv) != 2:
-        sys.exit(f'Usage: {sys.argv[0]} path-to-1099b-pdf')
-    text = subprocess.check_output(['pdftotext', '-raw', sys.argv[1], '-']).decode()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'input_path',
+        type=os.path.realpath,
+        help='The path to the 1099-B PDF document.')
+    args = parser.parse_args()
+    text = subprocess.check_output(['pdftotext', '-raw', args.input_path, '-']).decode()
 
     print('V042')
     print('A mssb_1099b_to_txf')


### PR DESCRIPTION
This uses argparse to parse the commandline arguments. This still expects the input PDF to be the first argument, the only difference is that this has auto-generated usage output and now also supports the `--help` switch as a way to print output.