### PR TITLE
Trim trailing zeroes for share quantity

### DIFF
--- a/mssb_1099b_to_txf.py
+++ b/mssb_1099b_to_txf.py
@@ -47,6 +47,13 @@ row_expr = re.compile(
         r'(?P<proceeds>\$[0-9,.]+)\s+'
         r'(?P<cost>\$[0-9,.]+)\s', re.DOTALL|re.MULTILINE)
 
+def formatShareQuantity(quantity):
+    if '.' in quantity:
+        # Trim off trailing zeroes. If there is no remaining fractional part,
+        # then also trim the decimal point.
+        return quantity.rstrip('0').rstrip('.')
+    return quantity
+
 def parseAndSerializeRows(text, entry_code):
     output_rows = []
     for match in row_expr.finditer(text):
@@ -54,9 +61,12 @@ def parseAndSerializeRows(text, entry_code):
         output_rows.append('N' + entry_code)
         output_rows.append('C1')
         output_rows.append('L1')
+
         # Form 8949 documents "100 sh. XYZ Co." as the example format.
-        output_rows.append('P' + match.group('quantity') +
+        quantity = formatShareQuantity(match.group('quantity'))
+        output_rows.append('P' + quantity +
                            ' sh. of ' + match.group('descr'))
+
         output_rows.append('D' + match.group('acquired'))
         output_rows.append('D' + match.group('sold'))
         # These have a leading dollar sign.

--- a/mssb_test.py
+++ b/mssb_test.py
@@ -54,7 +54,7 @@ TD
 N711
 C1
 L1
-P123.450000 sh. of XYZ INC CL C
+P123.45 sh. of XYZ INC CL C
 D01/01/23
 D02/02/23
 $1,000.00
@@ -62,6 +62,22 @@ $1,100.00
 $
 ^
 """)
+
+    def testFormatShareQuantity(self):
+        self.assertEqual(mssb_1099b_to_txf.formatShareQuantity('123'), '123',
+                         'Whole numbers should be left as-is')
+        self.assertEqual(mssb_1099b_to_txf.formatShareQuantity('123.'),'123',
+                         'Remove decimal if there is no fractional part')
+        self.assertEqual(mssb_1099b_to_txf.formatShareQuantity('123.00'), '123',
+                         'Trim trailing zeros and decimal if the fractional part is zero')
+        self.assertEqual(mssb_1099b_to_txf.formatShareQuantity('45.6'), '45.6',
+                         'Leave fractional part if there are no trailing zeros')
+        self.assertEqual(mssb_1099b_to_txf.formatShareQuantity('45.60'), '45.6',
+                         'Trim trailing zeros but leave non-zero fractional part')
+        self.assertEqual(mssb_1099b_to_txf.formatShareQuantity('70'), '70',
+                         'Do not trim trailing zeros for whole numbers')
+        self.assertEqual(mssb_1099b_to_txf.formatShareQuantity('70.0'), '70',
+                         'Do not trim trailing zeros to the left of the decimal')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The trailing zeroes are redundant and clutter up form 8949.