### PR TITLE
Doc: update link to TXF spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ has been used to import only a few different 1099-Bs so you may encounter
 errors.
 
 The TXF format is relatively straightforward and text based. It's defined at
-https://www.taxdataexchange.org/txf/txf-spec.html
+https://taxdataexchange.org/docs/txf/v042/index.html.
 
 ## Install
 

--- a/mssb_1099b_to_txf.py
+++ b/mssb_1099b_to_txf.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Iterator, NamedTuple, Optional, TextIO
 
 # Codes and structure are defined at
-# https://www.taxdataexchange.org/txf/txf-spec.html
+# https://taxdataexchange.org/docs/txf/v042/reference-numbers-by-form.html
 CATEGORIES = {
         'Short Term – Noncovered Securities': '711',
         'Long Term – Noncovered Securities': '713',


### PR DESCRIPTION
No change to logic. I think the URL for the TXF spec moved. This updates the URL to point to the new location.